### PR TITLE
Added sending test data to Rollbar.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -13,8 +13,10 @@ namespace newism\rollbar;
 use Craft;
 use craft\base\Plugin as BasePlugin;
 use craft\events\ExceptionEvent;
+use craft\events\RegisterUrlRulesEvent;
 use craft\events\TemplateEvent;
 use craft\web\ErrorHandler;
+use craft\web\UrlManager;
 use craft\web\View;
 use newism\rollbar\models\Settings;
 use Rollbar\Rollbar;
@@ -95,6 +97,14 @@ class Plugin extends BasePlugin
                 }
             );
         }
+
+        Event::on(
+            UrlManager::class,
+            UrlManager::EVENT_REGISTER_CP_URL_RULES,
+            function (RegisterUrlRulesEvent $event) {
+                $event->rules['settings/plugins/newism-rollbar/test'] = 'newism-rollbar/admin/test';
+            }
+        );
 
         if($this->settings->enableJs && $this->settings->postClientItemAccessToken) {
             // Load JS before template is rendered

--- a/src/assetbundles/rollbar/RollbarAsset.php
+++ b/src/assetbundles/rollbar/RollbarAsset.php
@@ -56,9 +56,9 @@ class RollbarAsset extends AssetBundle
 //            'js/Rollbar.js',
 //        ];
 //
-//        $this->css = [
-//            'css/Rollbar.css',
-//        ];
+        $this->css = [
+            'css/Rollbar.css',
+        ];
 
         parent::init();
     }

--- a/src/assetbundles/rollbar/dist/css/Rollbar.css
+++ b/src/assetbundles/rollbar/dist/css/Rollbar.css
@@ -9,3 +9,9 @@
  * @package   Rollbar
  * @since     0.0.0
  */
+
+.notification {
+    margin-top: 0.5rem;
+    color: #0077ff;
+    font-size: medium;
+}

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace newism\rollbar\controllers;
+
+
+use craft\web\Controller;
+use newism\rollbar\Plugin;
+use Rollbar\Rollbar;
+use yii\helpers\Url;
+
+class AdminController extends Controller
+{
+
+    /**
+     * @throws \yii\web\ForbiddenHttpException
+     */
+    public function actionTest()
+    {
+        $this->requirePermission('admin');
+
+        $accessToken = Plugin::getInstance()->getSettings()->accessToken;
+        if (!empty($accessToken)) {
+            Rollbar::init(
+                [
+                    'access_token' => $accessToken,
+                    'environment' => CRAFT_ENVIRONMENT,
+                ]
+            );
+            Rollbar::info('test message from craft-rollbar');
+        }
+        \Craft::$app->session->setFlash('newism-rollbar-setting', 'Sent test message.');
+        return $this->redirect('/admin/settings/plugins/newism-rollbar');
+    }
+}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -26,7 +26,7 @@
 }) }}
 
 {% if (settings['accessToken']) %}
-    <a href="./newism-rollbar/test" class="btn">Send test message to Rollbar</a>
+    <a href="{{ cpUrl('settings/plugins/newism-rollbar/test') }}" class="btn">Send test message to Rollbar</a>
     {% set message = craft.app.session.getFlash('newism-rollbar-setting') %}
     {% if message|length > 0 %}
         <div class="notification">{{message}}</div>

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -25,6 +25,14 @@
     value: settings['accessToken']
 }) }}
 
+{% if (settings['accessToken']) %}
+    <a href="./newism-rollbar/test" class="btn">Send test message to Rollbar</a>
+    {% set message = craft.app.session.getFlash('newism-rollbar-setting') %}
+    {% if message|length > 0 %}
+        <div class="notification">{{message}}</div>
+    {% endif %}
+{% endif %}
+
 {{ forms.lightSwitchField({
     label: 'Enable Rollbar JS integration'|t('newism-rollbar'),
     instructions: 'See: <a href="https://docs.rollbar.com/docs/browser-js">https://docs.rollbar.com/docs/browser-js</a>',


### PR DESCRIPTION
When we create a new Rollbar project, the Rollbar project waits for data from the app. The Rollbar project shows a dashboard after receiving the first data.
So I propose to add a button sending a test data to Rollbar on the setting page.

Thank you.