### PR TITLE
added composer php version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     ],
     "require": {
         "craftcms/cms": "^3.1",
+        "php": "^7.1",
         "rollbar/rollbar": "^1.7"
     },
     "autoload": {


### PR DESCRIPTION
Resolve #8 

Composer version constraint for PHP, `^7.1` (equivalent to 7.1 =< PHP Version <= 7.9.*)

This accommodates the return types set in methods. Specifically return void