### PR TITLE
Added exception ignore list and fixed an issue with the path to macro

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -87,6 +87,12 @@ class Plugin extends BasePlugin
                 ErrorHandler::class,
                 ErrorHandler::EVENT_BEFORE_HANDLE_EXCEPTION,
                 function (ExceptionEvent $event) {
+                    //check to see if this exception type is in our ignore list
+                    $ignoreList = $this->settings->getExceptionsToIgnore();
+                    if(in_array(strtolower(get_class($this->event), $ignoreList))) {
+                        return;
+                    }
+
                     Rollbar::init(
                         [
                             'access_token' => $this->settings->accessToken,

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -88,8 +88,8 @@ class Plugin extends BasePlugin
                 ErrorHandler::EVENT_BEFORE_HANDLE_EXCEPTION,
                 function (ExceptionEvent $event) {
                     //check to see if this exception type is in our ignore list
-                    $ignoreList = $this->settings->getExceptionsToIgnore();
-                    if(in_array(strtolower(get_class($this->event), $ignoreList))) {
+                    $ignoreList = iterator_to_array($this->settings->getExceptionsToIgnore());
+                    if(in_array(strtolower(get_class($event->exception)), $ignoreList)) {
                         return;
                     }
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -42,6 +42,7 @@ class Settings extends Model
     public $accessToken;
     public $enableJs;
     public $postClientItemAccessToken;
+    public $exceptionIgnoreList;
 
     // Public Methods
     // =========================================================================
@@ -63,6 +64,23 @@ class Settings extends Model
             ['accessToken', 'default', 'value' => ''],
             ['postClientItemAccessToken', 'string'],
             ['postClientItemAccessToken', 'default', 'value' => ''],
+            ['exceptionIgnoreList', 'default', 'value' => ''],
         ];
     }
+
+    /**
+     * Returns an Traversable containing all ignored exceptions
+     * @return \Traversable
+     */
+    public function getExceptionsToIgnore() : \Traversable
+    {
+        if($this->exceptionIgnoreList != null)
+        {
+            foreach(explode(",", $this->exceptionIgnoreList) as $exception)
+            {
+                yield trim(strtolower($exception));
+            }
+        }
+    }
+
 }

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -56,3 +56,13 @@
     warning: macros.configWarning('postClientItemAccessToken', 'newism-rollbar'),
     errors: settings.getErrors('postClientItemAccessToken')
 }) }}
+
+{{ forms.textField({
+    label: 'Exceptions to Ignore (comma separated)'|t('newism-rollbar'),
+    instructions: 'If you wish Rollbar to ignore any exception types, please provide the fully qualified name here, separated by a comma',
+    id: 'exceptionIgnoreList',
+    name: 'exceptionIgnoreList',
+    value: settings['exceptionIgnoreList'],
+    warning: macros.configWarning('exceptionIgnoreList', 'newism-rollbar'),
+    errors: settings.getErrors('exceptionIgnoreList')
+}) }}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -15,7 +15,7 @@
 
 {% import '_includes/forms' as forms %}
 
-{% import 'newism-rollbar/settings/_includes/macros' as macros %}
+{% import 'newism-rollbar/_includes/macros' as macros %}
 
 {% do view.registerAssetBundle('newism\\rollbar\\assetbundles\\rollbar\\RollbarAsset') %}
 


### PR DESCRIPTION
Hi,

Go easy on me - my first GitHub PR!

I raised an issue where I would like to be able to list exception types to ignore and not send to rollbar.
Thought I would create a PR for the change. I also noticed that the settings page doesn't load currently due to a bad path to macros.twig.

Let me know if there is anything more you would like me to do.

Thanks!
