### PR TITLE
fix error Monolog\logger not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "craftcms/cms": "^3.1",
         "php": "^7.1",
-        "rollbar/rollbar": "^1.7"
+        "rollbar/rollbar": "^v2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Error  Monolog\logger missing 
![image](https://user-images.githubusercontent.com/16419586/117478875-9b73b880-af57-11eb-8e71-1176b35f591c.png)

For some reason rollbar/rollbar version 1.7.4 set  monolog logger as dev-required  instead of require.
![image](https://user-images.githubusercontent.com/16419586/117480150-21dcca00-af59-11eb-9ffe-92f604f06e25.png)
![image](https://user-images.githubusercontent.com/16419586/117480428-8009ad00-af59-11eb-8807-c3351792fa3d.png)

this gets resolved with the version v1.8.1 forward
![image](https://user-images.githubusercontent.com/16419586/117480654-c828cf80-af59-11eb-86e9-1e65dfcb33a3.png)


Its also recomended the use of  the version ^2 for php 7
![image](https://user-images.githubusercontent.com/16419586/117480707-dd056300-af59-11eb-9433-a619a781fd41.png)

https://packagist.org/packages/rollbar/rollbar#v2.1.0
