### PR TITLE
Craft 4.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1 align="center">Rollbar plugin for Craft CMS</h1>
 
-This plugin provides an [Rollbar](https://rollbar.com) integration for [Craft CMS v4.x](https://craftcms.com).
+This plugin provides [Rollbar](https://rollbar.com) integration for [Craft CMS](https://craftcms.com).
 
 ## Features
 
@@ -61,7 +61,7 @@ You may then decide to configure your Rollbar gateway using a [config file](http
 ## Support
 
 If you've found a bug, or would like to make a feature request,
-head to the [GitHub Repo](https://github.com/chrismou/craft-rollbar/issues) and file an issue. 
+head to the [GitHub Repo](https://github.com/newism/craft-rollbar/issues) and file an issue. 
 Pull requests are also most welcome!
 
 ### Email
@@ -70,4 +70,4 @@ Any feedback, comments, questions or suggestions please email us at `dev at mou.
 
 ----
 
-Maintained by [Chris Chrisostomou](https://mou.me) with thanks to the original developer, [Newism](https://newism.com.au)
+Brought to you by [Newism](https://newism.com.au), maintained by [Chris Chrisostomou](https://mou.me)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1 align="center">Rollbar plugin for Craft CMS</h1>
 
-This plugin provides an [Rollbar](https://rollbar.com) integration for [Craft CMS v3.x](https://craftcms.com).
+This plugin provides an [Rollbar](https://rollbar.com) integration for [Craft CMS v4.x](https://craftcms.com).
 
 ## Features
 
@@ -56,41 +56,18 @@ You may then decide to configure your Rollbar gateway using a [config file](http
         
         // If you wish Rollbar to ignore any exception types, please provide the fully qualified name here, separated by a comma
         'exceptionIgnoreList' => '',
-    ]; 
-
-## Roadmap
-
-1. Implement logging levels
-2. More configuration options
+    ];
 
 ## Support
 
-### GitHub
-
 If you've found a bug, or would like to make a feature request,
-head to the [GitHub Repo](https://github.com/newism/craft-rollbar/issues) and file an issue. 
+head to the [GitHub Repo](https://github.com/chrismou/craft-rollbar/issues) and file an issue. 
 Pull requests are also most welcome!
-
-### Twitter
-
-Get our attention on Twitter by using the `#craftcms` hashtag and mentioning [@newism](https://twitter.com/newism)
-
-### Stack Exchange
-
-Ask a question via the [Craft Stack Exchange](http://craftcms.stackexchange.com/) and tag your question with `plugin-newism-craft-rollbar`.
 
 ### Email
 
-Any feedback, comments, questions or suggestions please email us at `support at newism.com.au`.
-
-## Licensing
-
-You can try this plugin in a development environment for as long as you like.
-
-For more information, see [Craft's Commercial Plugin Licensing](https://docs.craftcms.com/v3/plugins.html#commercial-plugin-licensing).
+Any feedback, comments, questions or suggestions please email us at `dev at mou.me`.
 
 ----
 
-<img src="./src/newism-logo.svg" width="100" height="100" alt="Afterpay for Craft Commerce icon">
-
-Brought to you by [Newism](https://newism.com.au)
+Maintained by [Chris Chrisostomou](https://mou.me) with thanks to the original developer, [Newism](https://newism.com.au)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1 align="center">Rollbar plugin for Craft CMS</h1>
 
-This plugin provides [Rollbar](https://rollbar.com) integration for [Craft CMS](https://craftcms.com).
+This plugin provides a [Rollbar](https://rollbar.com) integration for [Craft CMS](https://craftcms.com).
 
 ## Features
 
@@ -11,13 +11,13 @@ This plugin provides [Rollbar](https://rollbar.com) integration for [Craft CMS](
 
 ## Requirements
 
-This plugin requires Craft CMS 3.1 or later
+This plugin requires Craft CMS 4 or later. For Craft 3 support, please use the 3.x branch.
 
 ## Installation
 
 ### Plugin Store
 
-To install `Rollbar`, navigate to the Plugin Store section of your Craft control panel, search for `Rollbar`, and click the Try button.
+To install [Rollbar](https://rollbar.com/), navigate to the Plugin Store section of your Craft control panel, search for `Rollbar`, and click the Install button.
 
 ### Composer
 
@@ -37,11 +37,14 @@ You can also add the package to your project using Composer.
 
 First you'll need to setup a [Rollbar account](https://rollbar.com/).
 
-Once you have an account you'll be provided with an `Access Key`. 
+Once you have an account and created your project, you'll be provided with an `Access Key`. We recommend adding this 
+to your `.env` file. Then navigate to Settings > Plugins > Rollbar and start typing the name of your environment 
+variable in the `Access Token` field, until you see your variable name in the autocomplete box.
 
-To add the Afterpay payment gateway, go to Settings → Plugins → Rollbar and enter the access key.
+In order to log JS exceptions, you'll also need to add your `postClientItemAccessToken` using the same method as above.
 
-You may then decide to configure your Rollbar gateway using a [config file](https://docs.craftcms.com/commerce/v2/gateway-config.html#gateway-configuration). An example file looks like:
+You can also configure your Rollbar gateway using a [config file](https://docs.craftcms.com/commerce/v2/gateway-config.html#gateway-configuration). 
+An example file looks like:
 
     <?php
     return [

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,9 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.5.0",
-        "rollbar/rollbar": "^2.0"
+        "php": ">=8.0",
+        "craftcms/cms": "^4.0.0-alpha.1",
+        "rollbar/rollbar": "^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -35,5 +36,11 @@
         "handle": "newism-rollbar",
         "hasCpSettings": true,
         "hasCpSection": false
+    },
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true,
+            "craftcms/plugin-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.0.2 <9.0",
         "craftcms/cms": "^4.0.0-alpha.1",
         "rollbar/rollbar": "^3.0"
     },

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -96,7 +96,7 @@ class Plugin extends BasePlugin
 
                     Rollbar::init(
                         [
-                            'access_token' => $this->settings->accessToken,
+                            'access_token' => $this->settings->getAccessToken(),
                             'environment' => App::env('CRAFT_ENVIRONMENT'),
                         ]
                     );
@@ -113,7 +113,7 @@ class Plugin extends BasePlugin
             }
         );
 
-        if($this->settings->enableJs && $this->settings->postClientItemAccessToken) {
+        if($this->settings->enableJs && $this->settings->getPostClientItemAccessToken()) {
             // Load JS before template is rendered
             Event::on(
                 View::class,
@@ -145,14 +145,6 @@ class Plugin extends BasePlugin
         return new Settings();
     }
 
-    /**
-     * Returns the rendered settings HTML, which will be inserted into the content
-     * block on the settings page.
-     *
-     * @return string
-     * @throws \Twig_Error_Loader
-     * @throws \yii\base\Exception
-     */
     protected function settingsHtml(): string
     {
         return Craft::$app->view->renderTemplate(

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -15,6 +15,7 @@ use craft\base\Plugin as BasePlugin;
 use craft\events\ExceptionEvent;
 use craft\events\RegisterUrlRulesEvent;
 use craft\events\TemplateEvent;
+use craft\helpers\App;
 use craft\web\ErrorHandler;
 use craft\web\UrlManager;
 use craft\web\View;
@@ -96,7 +97,7 @@ class Plugin extends BasePlugin
                     Rollbar::init(
                         [
                             'access_token' => $this->settings->accessToken,
-                            'environment' => CRAFT_ENVIRONMENT,
+                            'environment' => App::env('CRAFT_ENVIRONMENT'),
                         ]
                     );
                     Rollbar::error($event->exception);
@@ -123,7 +124,7 @@ class Plugin extends BasePlugin
                         'accessToken' => $this->settings->postClientItemAccessToken,
                         'captureUncaught' => true,
                         'payload' => [
-                            'environment' => CRAFT_ENVIRONMENT,
+                            'environment' => App::env('CRAFT_ENVIRONMENT'),
                         ],
                     ]);
                     $rollbarJs = $rollbarJsHelper->configJsTag() . $rollbarJsHelper->jsSnippet();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * NSM Rollbar plugin for Craft CMS 3.x
+ * NSM Rollbar plugin for Craft CMS
  *
  * Rollbar integration for CraftCMS
  *

--- a/src/assetbundles/Rollbar/RollbarAsset.php
+++ b/src/assetbundles/Rollbar/RollbarAsset.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * NSM Rollbar plugin for Craft CMS 3.x
+ * NSM Rollbar plugin for Craft CMS
  *
  * Rollbar integration for CraftCMS
  *

--- a/src/config.php
+++ b/src/config.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * NSM Rollbar plugin for Craft CMS 3.x
+ * NSM Rollbar plugin for Craft CMS
  *
  * Rollbar integration for CraftCMS
  *

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -4,6 +4,7 @@
 namespace newism\rollbar\controllers;
 
 
+use craft\helpers\App;
 use craft\web\Controller;
 use newism\rollbar\Plugin;
 use Rollbar\Rollbar;
@@ -11,10 +12,6 @@ use yii\helpers\Url;
 
 class AdminController extends Controller
 {
-
-    /**
-     * @throws \yii\web\ForbiddenHttpException
-     */
     public function actionTest()
     {
         $this->requirePermission('admin');
@@ -24,7 +21,7 @@ class AdminController extends Controller
             Rollbar::init(
                 [
                     'access_token' => $accessToken,
-                    'environment' => CRAFT_ENVIRONMENT,
+                    'environment' => App::env('CRAFT_ENVIRONMENT'),
                 ]
             );
             Rollbar::info('test message from craft-rollbar');

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -57,7 +57,7 @@ class Settings extends Model
      *
      * @return array
      */
-    public function rules()
+    public function rules(): array
     {
         return [
             ['accessToken', 'string'],

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * NSM Rollbar plugin for Craft CMS 3.x
+ * NSM Rollbar plugin for Craft CMS
  *
  * Rollbar integration for CraftCMS
  *

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -10,9 +10,8 @@
 
 namespace newism\rollbar\models;
 
-use newism\rollbar\Plugin;
-
-use Craft;
+use craft\behaviors\EnvAttributeParserBehavior;
+use craft\helpers\App;
 use craft\base\Model;
 
 /**
@@ -61,10 +60,19 @@ class Settings extends Model
     {
         return [
             ['accessToken', 'string'],
-            ['accessToken', 'default', 'value' => ''],
+            ['accessToken', 'required'],
             ['postClientItemAccessToken', 'string'],
-            ['postClientItemAccessToken', 'default', 'value' => ''],
             ['exceptionIgnoreList', 'default', 'value' => ''],
+        ];
+    }
+
+    public function behaviors() :array
+    {
+        return [
+            'parser' => [
+                'class' => EnvAttributeParserBehavior::class,
+                'attributes' => ['accessToken', 'postClientItemAccessToken'],
+            ],
         ];
     }
 
@@ -83,4 +91,13 @@ class Settings extends Model
         }
     }
 
+    public function getAccessToken(): string
+    {
+        return App::parseEnv($this->accessToken);
+    }
+
+    public function getPostClientItemAccessToken(): string
+    {
+        return App::parseEnv($this->postClientItemAccessToken);
+    }
 }

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -19,14 +19,16 @@
 
 {% do view.registerAssetBundle('newism\\rollbar\\assetbundles\\Rollbar\\RollbarAsset') %}
 
-{{ forms.textField({
+{{ forms.autoSuggestField({
     label: 'Access Token'|t('newism-rollbar'),
     instructions: 'Your project\'s <code>post_server_item</code> access token, which you can find in the Rollbar.com interface.',
     id: 'accessToken',
     name: 'accessToken',
     value: settings['accessToken'],
+    required: true,
     warning: macros.configWarning('accessToken', 'newism-rollbar'),
-    errors: settings.getErrors('accessToken')
+    errors: settings.getErrors('accessToken'),
+    suggestEnvVars: true
 }) }}
 
 {% if (settings['accessToken']) %}
@@ -47,14 +49,15 @@
     errors: settings.getErrors('enableJs')
 }) }}
 
-{{ forms.textField({
+{{ forms.autoSuggestField({
     label: 'Post Client Item Access Token'|t('newism-rollbar'),
     instructions: 'Your project\'s <code>post_client_item</code> access token, which you can find in the Rollbar.com interface.',
     id: 'postClientItemAccessToken',
     name: 'postClientItemAccessToken',
     value: settings['postClientItemAccessToken'],
     warning: macros.configWarning('postClientItemAccessToken', 'newism-rollbar'),
-    errors: settings.getErrors('postClientItemAccessToken')
+    errors: settings.getErrors('postClientItemAccessToken'),
+    suggestEnvVars: true
 }) }}
 
 {{ forms.textField({

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -1,7 +1,7 @@
 {# @var craft \craft\web\twig\variables\CraftVariable #}
 {#
 /**
- * NSM Rollbar plugin for Craft CMS 3.x
+ * NSM Rollbar plugin for Craft CMS
  *
  * NSM Rollbar Settings.twig
  *

--- a/src/translations/en/newism-rollbar.php
+++ b/src/translations/en/newism-rollbar.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * NSM Rollbar plugin for Craft CMS 3.x
+ * NSM Rollbar plugin for Craft CMS
  *
  * Rollbar integration for CraftCMS
  *


### PR DESCRIPTION
As discussed, this adds Craft 4 support, plus support for .env based access tokens

Have tidied up a bit and stripped out references to 3.x throughout, plus implemented the changes you mentioned in the other draft PR.

Composer versions have been synced with Craft/Rollbar support - Craft4 requires PHP 8.0.2+ so have bumped the Rollbar plugin to 3 as that also requires 8+. There's doesn't appear to be any breaking changes other than the PHP version.

Prior to merging this I'd propose creating a 3.x branch/tag from current master.  Then once this is merged, we can branch/tag 4.x, make sure the Craft plugin site knows it now has 4.x support, then I'll follow up with another PR to add Craft 5.x support. I'm not sure how the Craft plugin site works - it might pick up version support by tags, or we may have to go in and explicitly tell it what versions are supported.

Let me know if you spot any issues 👍🏼 